### PR TITLE
Remove unused dependencies

### DIFF
--- a/iot-springboot-dashboard/pom.xml
+++ b/iot-springboot-dashboard/pom.xml
@@ -23,11 +23,29 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-logging</artifactId>
 				</exclusion>
+				<exclusion>
+                    			<groupId>javax.validation</groupId>
+                    			<artifactId>validation-api</artifactId>
+                		</exclusion>
+                		<exclusion>
+                    			<groupId>org.springframework.boot</groupId>
+                    			<artifactId>spring-boot-starter-tomcat</artifactId>
+                		</exclusion>
+				<exclusion>
+				    <groupId>org.springframework.boot</groupId>
+				    <artifactId>spring-boot-starter-validation</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-cassandra</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>org.springframework.boot</groupId>
+				    <artifactId>spring-boot-starter</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 		<!-- Other dependencies -->
 		<dependency>


### PR DESCRIPTION
@baghelamit Hi, I am a user of project **_com.iot.app.springboot:iot-springboot-dashboard:1.0.0_**. I found that its pom file introduced **_49_** dependencies. However, among them, **_10_** libraries (**_20%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.iot.app.springboot:iot-springboot-dashboard:1.0.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.hibernate:hibernate-validator:jar:5.2.4.Final:compile
org.springframework.boot:spring-boot-starter-validation:jar:1.3.5.RELEASE:compile
org.springframework.boot:spring-boot-starter-tomcat:jar:1.3.5.RELEASE:compile
com.fasterxml:classmate:jar:1.1.0:compile
org.apache.tomcat.embed:tomcat-embed-core:jar:8.0.33:compile
org.apache.tomcat.embed:tomcat-embed-el:jar:8.0.33:compile
org.apache.tomcat.embed:tomcat-embed-logging-juli:jar:8.0.33:compile
org.apache.tomcat.embed:tomcat-embed-websocket:jar:8.0.33:compile
javax.validation:validation-api:jar:1.1.0.Final:compile
org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
</code></pre>